### PR TITLE
Fix credits for b02d14a

### DIFF
--- a/app/models/names_manager.rb
+++ b/app/models/names_manager.rb
@@ -1013,6 +1013,9 @@ module NamesManager
       when 'thanks Pratik!'
         # see https://github.com/rails/rails/commit/a6467802ff2be35c6665635f1cdfdcea07aeaa12
         nil
+      when 'type="month"'
+        # see https://github.com/rails/rails/commit/b02d14aad515a039c284c93a68845503dc1658e2
+        nil
       when /ci skip/i
         nil
       when 'Carlhuda'

--- a/test/unit/names_manager_test.rb
+++ b/test/unit/names_manager_test.rb
@@ -40,6 +40,7 @@ class NamesManagerTest < ActiveSupport::TestCase
     assert_nil NamesManager.handle_special_cases('state:committed #969')
     assert_nil NamesManager.handle_special_cases('status:committed #1008')
     assert_nil NamesManager.handle_special_cases('#https://rails.lighthouseapp.com/attachments/106066/0001-Ensure-SqlBypass-use-ActiveRecord-Base-connection.patch state:committed')
+    assert_nil NamesManager.handle_special_cases('type="month"')
     assert_equal ['Yehuda Katz', 'Carl Lerche'], NamesManager.handle_special_cases('Carlhuda')
     assert_equal 'Mislav Marohnić', NamesManager.handle_special_cases('=?utf-8?q?Mislav=20Marohni=C4=87?=')
     assert_equal 'Adam Cigánek', NamesManager.handle_special_cases('=?utf-8?q?Adam=20Cig=C3=A1nek?=')


### PR DESCRIPTION
It should fix the credits for rails/rails@b02d14a that is currently given to [type="month"](http://contributors.rubyonrails.org/contributors/type-month/commits). Funny.

I'm not sure if this patch is 100% right. But let me know if it's wrong and what I could do instead.

Thanks.
