### PR TITLE
Fix attribution for old commit

### DIFF
--- a/app/models/names_manager.rb
+++ b/app/models/names_manager.rb
@@ -119,12 +119,12 @@ module NamesManager
 
   def self.authors_of_special_cased_commits(commit)
     case commit.sha1
-    # This was a commit backported from 2.3 that missed Dana in the way.
     when '1382f4de1f9b0e443e7884bd4da53c20f0754568'
+      # This was a commit backported from 2.3 that missed Dana in the way.
       ['David Burger', 'Dana Jones']
-    # The following patch comes from this ticket https://rails.lighthouseapp.com/projects/8994/tickets/2856
-    # but Yehuda told me credit for that commit was screwed up.
     when '882dd4e6054470ee56c46ab1432861952c81b633'
+      # The following patch comes from this ticket https://rails.lighthouseapp.com/projects/8994/tickets/2856
+      # but Yehuda told me credit for that commit was screwed up.
       ['David Calavera']
     when 'f9a02b12d15bdbd3c2ed18b16b31b712a77027bc'
       # The attribution is done with parens in a way we do not extract.


### PR DESCRIPTION
The commit [3582bce](https://github.com/rails/rails/commit/3582bce6fdb30730b34b91a17b8bb33066eed7b8) fixing the old trac ticket  #9312 was wrongly attributed. 
The attribution was ammended in the next commit ([33736b](https://github.com/rails/rails/commit/33736bc18a9733d95953f6eaec924db10badc908)) but the contributors app was missing that information. This PR fixes it adding the commit to the special-cases list.
