### PR TITLE
Add mapping for myself

### DIFF
--- a/app/models/names_manager.rb
+++ b/app/models/names_manager.rb
@@ -698,6 +698,7 @@ module NamesManager
   map 'Markus Roberts',             "MarkusQ\100reality.com"
   map 'Marten Veldthuis',           'Marten'
   map 'Martin Emde',                "zraii\100comcast.net", "martin.emde\100gmail.com"
+  map 'Martin Schuerrer',           "@MSch", "MSch", "Martin Schürrer"
   map 'Masashi Shimbo',             "shimbo\100is.naist.jp"
   map 'Mark Daggett',               'heavysixer'
   map 'Marshall Roch',              'mroch'


### PR DESCRIPTION
I got listed as `@MSch` for these commits: http://contributors.rubyonrails.org/contributors/msch/commits/

And I'm "Martin Schürrer" here: http://contributors.rubyonrails.org/contributors/martin-schurrer/commits

I'd prefer to be "Martin Schuerrer" everywhere. This PR should do that I think.
