### PR TITLE
Updated readme: setup script is now at bin/setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the application behind http://contributors.rubyonrails.org.
 Use the setup script to configure your application to be able to run the tests:
 
 ```
-script/setup
+bin/setup
 ```
 
 After this you can use the Rails rake tasks:


### PR DESCRIPTION
Just a minor update in README, replace `script/setup` with `bin/setup`
