### PR TITLE
Link the rails repository to sync the contributors App

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,7 +11,7 @@ set :branch, :master
 set :log_level, :info
 
 set :linked_files, %w{config/database.yml}
-set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets public/system public/assets}
+set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets public/system public/assets rails.git}
 
 set :keep_releases, 5
 


### PR DESCRIPTION
The repository were not linked (it was not even in the shared folder) and the `Repo.sync` task were failing.

Now it is working fine.

@fxn I were looking at the server script, is this repository already running there https://github.com/rails/rails-docs-server?
