### PR TITLE
Remove dead 'ecosystem' lnk for top menu bar

### DIFF
--- a/app/views/layouts/_top_bar_content.html.erb
+++ b/app/views/layouts/_top_bar_content.html.erb
@@ -9,6 +9,5 @@
 <a href="https://github.com/rails/rails" title="Ruby on Rails - Code">Code</a> |
 <a href="http://rubyonrails.org/screencasts" title="Ruby on Rails - Screencasts">Screencasts</a> |
 <a href="http://rubyonrails.org/documentation" title="Ruby on Rails - Documentation">Documentation</a> |
-<a href="http://rubyonrails.org/ecosystem" title="Ruby on Rails - Ecosystem">Ecosystem</a> |
 <a href="http://rubyonrails.org/community" title="Ruby on Rails - Community">Community</a> |
 <a href="http://weblog.rubyonrails.org/" title="Ruby on Rails - Blog">Blog</a>


### PR DESCRIPTION
The link to http://rubyonrails.org/ecosystem is dead. 

The 'ecosystem' link has already been removed from http://edgeguides.rubyonrails.org/ and we should do the same.
