### PR TITLE
Map Dylan Smith to Dylan Thacker-Smith due to change of last name.

### DIFF
--- a/app/models/names_manager.rb
+++ b/app/models/names_manager.rb
@@ -421,6 +421,7 @@ module NamesManager
   map 'Duncan Beevers',             'duncanbeevers'
   map 'Duncan Robertson',           "duncan\100whomwah.com"
   map 'Dustin Curtis',              'dcurtis'
+  map 'Dylan Thacker-Smith',        'Dylan Smith'
   map 'Eaden McKee',                'eadz', 'Eadz'
   map 'Eddie Cianci',               'defeated'
   map 'Eddie Stanley',              "eddiewould\100paradise.net.nz"


### PR DESCRIPTION
Currently my commits are split between http://contributors.rubyonrails.org/contributors/dylan-smith/commits and http://contributors.rubyonrails.org/contributors/dylan-thacker-smith/commits since I changed my last name from Smith to Thacker-Smith.

E.g. the commit from my first rails pull request (https://github.com/rails/rails/pull/6759/commits) contains the first commit in http://contributors.rubyonrails.org/contributors/dylan-smith/commits, and my last pull request (https://github.com/rails/rails/pull/16069/commits) contains the last commit in http://contributors.rubyonrails.org/contributors/dylan-thacker-smith/commits, yet both pull requests were opened using my github user account.
