### PR TITLE
Remove deprecated db:test:load from setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -15,4 +15,4 @@ then
     cp config/database.yml.example $database_config
 fi
 
-bundle exec rake db:create:all db:schema:load db:test:load
+bundle exec rake db:create:all db:schema:load


### PR DESCRIPTION
When I run `bin/setup` I get the following message at the end:

> WARNING: db:test:load is deprecated. The Rails test helper now maintains your test schema automatically, see the release notes for details.

This commit removes the warning message above.
