### PR TITLE
Adds an alias to my name

### DIFF
--- a/app/models/names_manager.rb
+++ b/app/models/names_manager.rb
@@ -405,6 +405,7 @@ module NamesManager
   map 'Derek DeVries',              'devrieda'
   map 'Derrick Spell',              "derrickspell\100cdmplus.com"
   map 'Dick Davies',                'rasputnik'
+  map 'Diego Algorta'               'Diego Algorta Casamayou'
   map 'Diego Giorgini',             'ogeidix'
   map 'Dieter Komendera',           'kommen'
   map 'Dirkjan Bussink',            'dbussink'


### PR DESCRIPTION
I was credited in https://github.com/rails/rails/commit/88f2284b32b5cc302d2b37c0ad3c2667d4c58c6a with my full Hispanic naming convention which I don't normally use anymore to avoid people thinking Casamayou is my last name.
