### PR TITLE
Use ActiveSupport::Testing::TimeHelpers instead of delorean

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ group :development do
 end
 
 group :test do
-  gem 'delorean'
   gem 'rails-controller-testing'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,6 @@ GEM
     capistrano3-puma (1.2.1)
       capistrano (~> 3.0)
       puma (>= 2.6)
-    chronic (0.10.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -80,8 +79,6 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
-    delorean (2.1.0)
-      chronic
     erubi (1.7.1)
     execjs (2.7.0)
     ffi (1.9.23)
@@ -205,7 +202,6 @@ DEPENDENCIES
   capistrano-rvm (= 0.1.1)
   capistrano3-puma (~> 1.0)
   coffee-rails (~> 4.2.1)
-  delorean
   listen (>= 3.0.5, < 3.2)
   pg
   puma (~> 3.7)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,7 @@ class ActiveSupport::TestCase
   fixtures :all
 
   def time_travel(&block)
-    Delorean.time_travel_to(TODAY, &block)
+    travel_to(TODAY, &block)
   end
 
   def read_fixture(name)


### PR DESCRIPTION
## Summary

* For reducing gem to need to maintain, it replaced.
* We don't need no longer delorean or timecop.