### PR TITLE
Remove needless validation in Contribution

### DIFF
--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -1,6 +1,4 @@
 class Contribution < ApplicationRecord
   belongs_to :contributor
   belongs_to :commit
-
-  validates :contributor_id, :commit_id, :presence => true
 end


### PR DESCRIPTION
## Summary

* Since Rails v5, belongs_to association set presence validator by default.