### PR TITLE
Upgrade rugged 0.21.0 to 0.27.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'rails', '~> 5.1.4'
 gem 'pg'
-gem 'rugged', '0.21.0'
+gem 'rugged', '0.27.0'
 gem 'unf'
 gem 'turbolinks', '~> 5'
 gem 'actionpack-page_caching', github: 'rails/actionpack-page_caching', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     rbnacl-libsodium (1.0.16)
       rbnacl (>= 3.0.1)
     ruby_dep (1.5.0)
-    rugged (0.21.0)
+    rugged (0.27.0)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -209,7 +209,7 @@ DEPENDENCIES
   rails-controller-testing
   rbnacl (>= 3.2, < 5.0)
   rbnacl-libsodium
-  rugged (= 0.21.0)
+  rugged (= 0.27.0)
   sass-rails (~> 5.0)
   turbolinks (~> 5)
   uglifier (>= 1.3.0)


### PR DESCRIPTION
## Summary

* It's no problem to upgrade rugged from 0.21.0 to 0.27.0.
* [CHANGELOG](https://github.com/libgit2/rugged/blob/master/CHANGELOG.md)