### PR TITLE
Use alpine image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.4-alpine
 
 # LANG as recommended in the Encoding section of https://hub.docker.com/_/ruby/.
 ENV LANG C.UTF-8


### PR DESCRIPTION
`ruby:2.4` is ubuntu, so build is failed. Seems it have to use `alpine` image (build is succeed)