### PR TITLE
Use https with weblog URI

### DIFF
--- a/app/views/layouts/_top_bar_content.html.erb
+++ b/app/views/layouts/_top_bar_content.html.erb
@@ -3,7 +3,7 @@
   <a href="http://rubyonrails.org/" title="Ruby on Rails" class="home">rubyonrails.org:</a>
 </strong>
 
-<a href="http://weblog.rubyonrails.org/" title="Ruby on Rails - Blog">Blog</a> |
+<a href="https://weblog.rubyonrails.org/" title="Ruby on Rails - Blog">Blog</a> |
 <a href="http://guides.rubyonrails.org/" title="Ruby on Rails - Guides">Guides</a> |
 <a href="http://api.rubyonrails.org/" title="Ruby on Rails - API">API</a> |
 <a href="http://stackoverflow.com/questions/tagged/ruby-on-rails" title="Ruby on Rails - Ask for help">Ask for help</a> |


### PR DESCRIPTION
### Summary

I've changed weblog (GitHub page)'s protocol.

See: Custom domains on GitHub Pages gain support for HTTPS
https://blog.github.com/2018-05-01-github-pages-custom-domains-https/