### PR TITLE
Fix credit for Alberto Almagro

### DIFF
--- a/app/models/names_manager/canonical_names.rb
+++ b/app/models/names_manager/canonical_names.rb
@@ -144,6 +144,7 @@ module NamesManager
     map 'Akshay Vishnoi',             'Mr A'
     map 'Alan Francis',               'alancfrancis', 'acf',"alancfrancis\100gmail.com"
     map 'Albert Lash',                'docunext'
+    map 'Alberto Almagro',            'Alberto Almagro Sotelo'
     map 'Alex Chaffee',               'alexch'
     map 'Alex Mishyn',                'amishyn'
     map 'Alex Pooley',                "alex\100msgpad.com"

--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -148,6 +148,10 @@ module Credits
       assert_contributor_names 'dfd0bdf', 'Alan Francis'
     end
 
+    test 'Alberto Almagro Sotelo' do
+      assert_contributor_names '5c62bd5', 'Gannon McGibbon', 'Alberto Almagro'
+    end
+
     test 'Aleksey Kondratenko' do
       assert_contributor_names 'a9113b8', 'Aliaksey Kandratsenka'
     end


### PR DESCRIPTION
Hello,

This pull request gives proper credit to @albertoalmagro (c.f. https://github.com/rails/rails/pull/34241#discussion_r227133308) since the commit refers to his full name while his Git name is in a shorter form (and thus, already got credit on Rails Contributors with the latter).

This change has been tested locally.

Have a nice day !