### PR TITLE
Add migration versions

### DIFF
--- a/db/migrate/20141101094005_initial_schema.rb
+++ b/db/migrate/20141101094005_initial_schema.rb
@@ -1,4 +1,4 @@
-class InitialSchema < ActiveRecord::Migration
+class InitialSchema < ActiveRecord::Migration[4.2]
   def up
     create_table :commits do |t|
       t.string   :sha1,            null: false

--- a/db/migrate/20150326181907_add_first_contribution_at_to_contributors.rb
+++ b/db/migrate/20150326181907_add_first_contribution_at_to_contributors.rb
@@ -1,7 +1,7 @@
-class AddFirstContributionAtToContributors < ActiveRecord::Migration
+class AddFirstContributionAtToContributors < ActiveRecord::Migration[4.2]
   def up
     add_column :contributors, :first_contribution_at, :datetime
-    Contributor.fill_missing_first_contribution_timestamps
+    Contributor.try(:fill_missing_first_contribution_timestamps)
   end
 
   def down

--- a/db/migrate/20160512095609_rename_nmupdated.rb
+++ b/db/migrate/20160512095609_rename_nmupdated.rb
@@ -1,4 +1,4 @@
-class RenameNmupdated < ActiveRecord::Migration
+class RenameNmupdated < ActiveRecord::Migration[4.2]
   def change
     rename_column :repo_updates, :nmupdated, :rebuild_all
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,63 +10,59 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160512095609) do
+ActiveRecord::Schema.define(version: 2016_05_12_095609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "commits", force: :cascade do |t|
-    t.string   "sha1",            limit: 255, null: false
-    t.string   "author_email",    limit: 255, null: false
-    t.string   "author_name",     limit: 255, null: false
-    t.datetime "author_date",                 null: false
-    t.string   "committer_email", limit: 255, null: false
-    t.string   "committer_name",  limit: 255, null: false
-    t.datetime "committer_date",              null: false
-    t.text     "message",                     null: false
-    t.text     "diff"
-    t.integer  "release_id"
-    t.boolean  "merge",                       null: false
+  create_table "commits", id: :serial, force: :cascade do |t|
+    t.string "sha1", null: false
+    t.string "author_email", null: false
+    t.string "author_name", null: false
+    t.datetime "author_date", null: false
+    t.string "committer_email", null: false
+    t.string "committer_name", null: false
+    t.datetime "committer_date", null: false
+    t.text "message", null: false
+    t.text "diff"
+    t.integer "release_id"
+    t.boolean "merge", null: false
+    t.index ["release_id"], name: "index_commits_on_release_id"
+    t.index ["sha1"], name: "index_commits_on_sha1", unique: true
   end
 
-  add_index "commits", ["release_id"], name: "index_commits_on_release_id", using: :btree
-  add_index "commits", ["sha1"], name: "index_commits_on_sha1", unique: true, using: :btree
-
-  create_table "contributions", force: :cascade do |t|
+  create_table "contributions", id: :serial, force: :cascade do |t|
     t.integer "contributor_id", null: false
-    t.integer "commit_id",      null: false
+    t.integer "commit_id", null: false
+    t.index ["commit_id"], name: "index_contributions_on_commit_id"
+    t.index ["contributor_id"], name: "index_contributions_on_contributor_id"
   end
 
-  add_index "contributions", ["commit_id"], name: "index_contributions_on_commit_id", using: :btree
-  add_index "contributions", ["contributor_id"], name: "index_contributions_on_contributor_id", using: :btree
-
-  create_table "contributors", force: :cascade do |t|
-    t.string   "name",                  limit: 255, null: false
-    t.string   "url_id",                limit: 255, null: false
-    t.integer  "rank"
+  create_table "contributors", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "url_id", null: false
+    t.integer "rank"
     t.datetime "first_contribution_at"
+    t.index ["name"], name: "index_contributors_on_name", unique: true
+    t.index ["url_id"], name: "index_contributors_on_url_id", unique: true
   end
 
-  add_index "contributors", ["name"], name: "index_contributors_on_name", unique: true, using: :btree
-  add_index "contributors", ["url_id"], name: "index_contributors_on_url_id", unique: true, using: :btree
-
-  create_table "releases", force: :cascade do |t|
-    t.string   "tag",   limit: 255, null: false
-    t.datetime "date",              null: false
-    t.integer  "major",             null: false
-    t.integer  "minor",             null: false
-    t.integer  "tiny",              null: false
-    t.integer  "patch",             null: false
+  create_table "releases", id: :serial, force: :cascade do |t|
+    t.string "tag", null: false
+    t.datetime "date", null: false
+    t.integer "major", null: false
+    t.integer "minor", null: false
+    t.integer "tiny", null: false
+    t.integer "patch", null: false
+    t.index ["tag"], name: "index_releases_on_tag", unique: true
   end
 
-  add_index "releases", ["tag"], name: "index_releases_on_tag", unique: true, using: :btree
-
-  create_table "repo_updates", force: :cascade do |t|
-    t.integer  "ncommits",    null: false
-    t.datetime "started_at",  null: false
-    t.datetime "ended_at",    null: false
-    t.integer  "nreleases",   null: false
-    t.boolean  "rebuild_all", null: false
+  create_table "repo_updates", id: :serial, force: :cascade do |t|
+    t.integer "ncommits", null: false
+    t.datetime "started_at", null: false
+    t.datetime "ended_at", null: false
+    t.integer "nreleases", null: false
+    t.boolean "rebuild_all", null: false
   end
 
 end


### PR DESCRIPTION
Add migration versions so they can be ran on a new machine (instead of raising an error), and use `try` for nonexistent fill method.