### PR TITLE
Fix tests

### DIFF
--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -1128,7 +1128,7 @@ module Credits
     end
 
     test 'dfens' do
-      assert_contributor_names 'ab9140f', 'Paweł Mikołajewski'
+      assert_contributor_names 'ab9140ff027', 'Paweł Mikołajewski'
     end
 
     test 'dharmatech' do
@@ -1201,10 +1201,6 @@ module Credits
 
     test "doppler\100gmail.com" do
       assert_contributor_names 'f4f7e75', 'David Rose'
-    end
-
-    test "dpiddy\100gmail.com" do
-      assert_contributor_names 'd9c0a37', 'Dan Peterson'
     end
 
     test 'dpmehta02' do
@@ -2215,10 +2211,6 @@ module Credits
       assert_contributor_names 'edb4208', 'Josh Starcher'
     end
 
-    test "joshknowles\100gmail.com" do
-      assert_contributor_names '7d01005', 'Josh Knowles'
-    end
-
     test 'joshpeek' do
       assert_contributor_names 'c57c721', 'Josh Peek'
     end
@@ -2688,7 +2680,7 @@ module Credits
     end
 
     test 'Lukasz Strzalkowski' do
-      assert_contributor_names 'f9b6b86', 'Łukasz Strzałkowski'
+      assert_contributor_names 'f9b6b865e60', 'Łukasz Strzałkowski'
     end
 
     test 'lukeludwig' do
@@ -3252,7 +3244,7 @@ module Credits
     end
 
     test "nils\100alumni.rice.edu" do
-      assert_contributor_names '64b7c5f', 'Nils Jonsson'
+      assert_contributor_names '64b7c5fbd19', 'Nils Jonsson'
     end
 
     test 'nilsga' do
@@ -3960,7 +3952,7 @@ module Credits
     end
 
     test "ryand-ruby\100zenspider.com" do
-      assert_contributor_names 'a2f0ae7', 'Ryan Davis (zenspider)'
+      assert_contributor_names '479c7cacd', 'Ryan Davis (zenspider)'
     end
 
     test 'ryepup' do

--- a/test/credits/disambiguation_test.rb
+++ b/test/credits/disambiguation_test.rb
@@ -26,7 +26,7 @@ module Credits
 
     test 'disambiguates unknown' do
       assert_contributor_names 'e813ad2a', 'Andrew Grimm'
-      assert_contributor_names '2414fdb2', 'Jens Kolind'
+      assert_contributor_names '2414fdb244c', 'Jens Kolind'
       assert_contributor_names '3833d45', 'Manish Puri'
     end
 

--- a/test/credits/heuristics_test.rb
+++ b/test/credits/heuristics_test.rb
@@ -23,7 +23,7 @@ module Credits
     #
     test 'captures credit in an isolated line' do
       # First line in body.
-      assert_contributor_names '9e9793b', 'Rafael Mendonça França', 'Yves Senn'
+      assert_contributor_names '9e9793b440c', 'Rafael Mendonça França', 'Yves Senn'
 
       # Line in the middle.
       assert_contributor_names '2a67e12', 'Matthew Draper', 'Yves Senn'

--- a/test/support/repo_creator.rb
+++ b/test/support/repo_creator.rb
@@ -1,0 +1,7 @@
+module RepoCreator
+  RAILS_GIT = Rails.root.join('rails.git')
+
+  unless RAILS_GIT.exist?
+    `git clone --mirror git://github.com/rails/rails.git #{RAILS_GIT}`
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
+require_relative 'support/repo_creator'
 require_relative 'support/assert_contributor_names'
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
Some tests appear to be using an outdated (ambiguous) SHA, and some use SHAs that no longer exist in (see `assert_contributor_names 'd9c0a37', 'Dan Peterson'`, `assert_contributor_names '7d01005', 'Josh Knowles'`, and `assert_contributor_names 'a2f0ae7', 'Ryan Davis (zenspider)'`) on a fresh clone of Rails.

I've also added some bootstrap code to automatically clone the rails repo when you run tests. Should this be in an initializer or the DB seeds instead?