### PR TITLE
Unify credits for Eileen M. Uchitelle

### DIFF
--- a/app/models/names_manager/canonical_names.rb
+++ b/app/models/names_manager/canonical_names.rb
@@ -387,7 +387,7 @@ module NamesManager
     map 'Edward Betts',               "edward\100debian.org"
     map 'Eelco Lempsink',             "rails\10033lc0.net"
     map 'Egor Homakov',               'homa', 'homakov', '@homakov'
-    map 'Eileen M. Uchitelle',        'eileencodes'
+    map 'Eileen M. Uchitelle',        'eileencodes', 'Eileen Uchitelle'
     map 'Elan Feingold',              "elan\100bluemandrill.com"
     map 'Elijah Miller',              "elijah.miller\100gmail.com", 'jqr'
     map 'Elliot Smith',               "elliot\100townx.org"

--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -1315,6 +1315,10 @@ module Credits
       assert_contributor_names '7caceee', 'Eileen M. Uchitelle'
     end
 
+    test 'Eileen Uchitelle' do
+      assert_contributor_names 'aec635d', 'Eileen M. Uchitelle'
+    end
+
     test 'ejy' do
       assert_contributor_names '740e531', 'Elliot Yates'
     end


### PR DESCRIPTION
### Summary
Currently `eileencodes` contributions are listed below [eileen-m-uchitelle](https://contributors.rubyonrails.org/contributors/eileen-m-uchitelle/commits) and [eileen-uchitelle](https://contributors.rubyonrails.org/contributors/eileen-uchitelle/commits). Let's put them together!