### PR TITLE
Add support for co-authored-by commits

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -143,6 +143,13 @@ protected
         break if contributor_names.any?
       end
 
+      # check for co-authored commits i.e: Co-authored-by: Helpful Person <helpful@example.com>
+      matches = body.scan(/^Co-authored-by:\s*(.*)\s*<.*>$/)
+      if matches.any?
+        co_author_names = matches.flatten
+        contributor_names = sanitize(co_author_names << author_name)
+      end
+
       if contributor_names.empty? && imported_from_svn?
         # Check the end of the body as last option.
         contributor_names = extract_contributor_names_from_text(body.sub(/git-svn-id:.*/m, ''))

--- a/app/views/faqs/show.html.erb
+++ b/app/views/faqs/show.html.erb
@@ -34,6 +34,10 @@
 <p>Git has no support for multiple authors, and again the project has figured out conventions to give credit for one commit to several people.</p>
 <p>See for example <%= link_to 'this commit with two authors', github_url_for_sha1('9e9793b440c044b765f2d1f702feeb92aef2b139') %>, or the CHANGELOG entry of <%= link_to 'this other one', github_url_for_sha1('ec20838381dc26b68142c84c0e03f523765b4aae') %>. The application understands those conventions and gives credit to all authors.</p>
 
+<h3>Multiple authors through Co-authored-by</h3>
+<p>GitHub has added support for multiple authors by using Co-authored-by annotations, see <%= link_to "here", "https://help.github.com/en/articles/creating-a-commit-with-multiple-authors" %> for more information.</p>
+<p>The project understands this form as well and will correctly attribute commits to multiple authors. See for example <%= link_to 'this commit with a co-author.', github_url_for_sha1("99e52ae7b1c621069f2971d2f352822f263efb49") %></p>
+
 <h3>Plural nicknames</h3>
 <p>A couple of nicknames refer to several people. For example, a commit by "Carlhuda" (like <%= link_to 'this one', github_url_for_sha1('c102db9367690af992786d2a62bbf8caeec88742') %>) has to be credited to Yehuda Katz and Carl Lerche.</p>
 
@@ -58,6 +62,16 @@
     [Author 1, Author 2, Author 3]
 </pre>
 <p>A few list separators are supported, but you can just stick with "&amp;" or "," for example.</p>
+<p> or you can use Co-authored-by with their name and email in individual lines:</p>
+<pre>
+    first line of commit message
+
+    message body line 1
+    message body line 2
+
+    Co-authored-by: Author 1 &lt;author1@example.com&gt;
+    Co-authored-by: Author 2 &lt;author2@example.com&gt;
+</pre>
 
 <h2 id="why-no-pagination">The home page has a huge table, no pagination?</h2>
 <p>That's by design.</p>

--- a/test/models/commit_test.rb
+++ b/test/models/commit_test.rb
@@ -122,4 +122,25 @@ class CommitTest < ActiveSupport::TestCase
       [Kevin Clark & Jeremy Hopple]
     MESSAGE
   end
+
+  def test_extracts_co_authored_by_names
+    message = <<~MESSAGE
+    Fixed a bad thing that did a broken thing
+
+      * Stop it doing a bad thing
+      * Make it do a good thing
+
+    Co-authored-by: Edward Vincent <edward.vincent@example.com>
+    Co-authored-by: William Fox <william.fox@example.com>
+    MESSAGE
+    rugged_commit = OpenStruct.new
+    rugged_commit.oid       = "123456789"
+    rugged_commit.author    = {name: 'Carla-Maria', email: 'carla@example.com', time: Time.now}
+    rugged_commit.committer = {name: 'Edward', email: 'Edward@example.com', time: Time.now}
+    rugged_commit.message   = message
+    rugged_commit.parents   = []
+    commit = Commit.import!(rugged_commit)
+
+    assert_equal ["Edward Vincent", "William Fox", "Carla-Maria"], commit.extract_contributor_names(Repo)
+  end
 end


### PR DESCRIPTION
Github added support for co-authored-by annotations to mark commits by multiple
authors, this patch makes it so that the app is able to understand this format
and attribute commits to the various committers correctly.

Fixes: #133

For this commit: https://github.com/rails/rails/commit/99e52ae7b1c621069f2971d2f352822f263efb49

This is what it looks like without the patch: 

![nay](https://user-images.githubusercontent.com/6386302/59884143-55be9e80-9385-11e9-97b0-b9878f186e62.png)

This is what it looks like with the patch:

![yay](https://user-images.githubusercontent.com/6386302/59884154-5bb47f80-9385-11e9-99c6-5b9082070f37.png)

cc: @fxn 