### PR TITLE
remove deprecated config

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,7 +44,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  # Prevent expensive template finalization at end of test suite runs.
-  config.action_view.finalize_compiled_template_methods = false
 end


### PR DESCRIPTION
action_view.finalize_compiled_template_methods is deprecated and setting it has
no effect. It generates a deprecation warning when running the tests, removing
the config removes the warning.