### PR TITLE
Ignore case for co-authored-by

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -145,7 +145,7 @@ protected
     end
 
     # See https://help.github.com/en/articles/creating-a-commit-with-multiple-authors.
-    co_authors = body.scan(/^Co-authored-by:(.*)$/)
+    co_authors = body.scan(/^Co-authored-by:(.*)$/i)
     return sanitize([author_name] + co_authors.flatten) if co_authors.any?
 
     # Check the end of the body as last option.

--- a/test/models/commit_test.rb
+++ b/test/models/commit_test.rb
@@ -157,4 +157,22 @@ class CommitTest < ActiveSupport::TestCase
 
     assert_equal expected_contributor_names, commit.extract_contributor_names(Repo.new)
   end
+
+  def test_extracts_co_authored_by_names_when_titlecase
+    commit = Commit.new(
+      author_name: 'Joel Hawksley',
+      message: <<~MESSAGE
+        `RenderingHelper` supports rendering objects that `respond_to?` `:render_in`
+
+        Co-Authored-By: Natasha Umer <natashau@github.com>
+      MESSAGE
+    )
+
+    expected_contributor_names = [
+      'Joel Hawksley',
+      'Natasha Umer'
+    ]
+
+    assert_equal expected_contributor_names, commit.extract_contributor_names(Repo.new)
+  end
 end


### PR DESCRIPTION
In rails/rails@13e2102 I used `Co-Authored-By` instead of
`Co-authored-by`. GitHub accepts both and I found other instances in the
codebase. If the contributors app is going to support `Co-authored-by`
we should ignore the case so that everyone gets credit.