### PR TITLE
Add mapping for Muhammad Muhammad Ibrahim

### DIFF
--- a/app/models/names_manager/canonical_names.rb
+++ b/app/models/names_manager/canonical_names.rb
@@ -821,6 +821,7 @@ module NamesManager
     map 'Mo Khan',                    'mo khan'
     map 'Mohamed Osama',              'oss92'
     map 'Moses Hohman',               'moses'
+    map 'Muhammad Muhammad Ibrahim',  'Muhammad'
     map 'Murahashi Sanemat Kenichi',  'sanemat'
     map 'Murray Steele',              'h-lame'
     map 'Nacho Caballero',            'nachocab'

--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -3183,6 +3183,10 @@ module Credits
       assert_contributor_names '74191ed', 'Mark J. Titorenko'
     end
 
+    test 'Muhammad' do
+      assert_contributor_names '73fdd4c', 'Muhammad Muhammad Ibrahim'
+    end
+
     test 'murphy' do
       assert_contributor_names 'dcc1549', 'Kornelius Kalnbach'
     end


### PR DESCRIPTION
I have two commits with different names:

1. [Muhammad](https://contributors.rubyonrails.org/contributors/muhammad/commits)
2. [Muhammad Muhammad Ibrahim](https://contributors.rubyonrails.org/contributors/muhammad-muhammad-ibrahim/commits)

This should list both of them under the second one.