### PR TITLE
update actionpack-page_caching to 1.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'puma', '~> 3.12'
 gem 'rugged', '0.27.0'
 gem 'unf'
 gem 'turbolinks', '~> 5'
-gem 'actionpack-page_caching', '~> 1.1'
+gem 'actionpack-page_caching', '~> 1.2.2'
 
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionpack-page_caching (1.2.0)
+    actionpack-page_caching (1.2.2)
       actionpack (>= 5.0.0)
     actiontext (6.0.3.rc1)
       actionpack (= 6.0.3.rc1)
@@ -213,7 +213,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack-page_caching (~> 1.1)
+  actionpack-page_caching (~> 1.2.2)
   bcrypt_pbkdf (>= 1.0, < 2.0)
   byebug
   capistrano (~> 3.10)


### PR DESCRIPTION
fix [CVE-2020-8159](https://groups.google.com/forum/#!topic/rubyonrails-security/CFRVkEytdP8)

(1.2.1 version has https://github.com/rails/actionpack-page_caching/issues/59 issue)