### PR TITLE
Add .tool-versions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .byebug_history
+.tool-versions
 /log
 /tmp
 /rails.git


### PR DESCRIPTION
I use asdf for managing Ruby versions. It creates this dotfile for the
same purpose as .ruby-version.

If people use asdf, they might unintentionally commit the dotfile.