### PR TITLE
Add canonical name 'Steven Abrams'

### DIFF
--- a/app/models/names_manager/canonical_names.rb
+++ b/app/models/names_manager/canonical_names.rb
@@ -1061,6 +1061,7 @@ module NamesManager
     map 'Stephen Touset',             "stephen\100touset.org"
     map 'Stephen Veiss',              'sveiss'
     map 'Stephen Veit',               "sveit\100tradeharbor.com"
+    map 'Steven Abrams',              'sabrams86'
     map 'Steve Agalloco',             'stve'
     map 'Steve Purcell',              "stephen_purcell\100yahoo.com"
     map 'Steve Richert',              'laserlemon'

--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -4491,6 +4491,10 @@ module Credits
       assert_contributor_names '3398f74', 'Stephen Veit'
     end
 
+    test "sabrams86" do
+      assert_contributor_names '95f4d75', 'Steven Abrams'
+    end
+
     test "sven\100c3d2.de" do
       assert_contributor_names '4b3e964', 'Sven Klemm'
     end


### PR DESCRIPTION
I have two commits listed under [sabrams86](https://contributors.rubyonrails.org/contributors/sabrams86/commits) and [Steven Abrams](https://contributors.rubyonrails.org/contributors/steven-abrams/commits).


[steve-abrams](https://github.com/steve-abrams) is my Github username and I go by Steven Abrams, so I created this PR to consolidate the credits.