### PR TITLE
fix attribution for commit of original shallow routes implementation

### DIFF
--- a/app/models/names_manager/hard_coded_authors.rb
+++ b/app/models/names_manager/hard_coded_authors.rb
@@ -98,6 +98,8 @@ module NamesManager
         ['Josh Peek', 'David Heinemeier Hansson']
       when 'fdbc55b9d55ae9d2b5b39be3ef4af5f60f6954a3', '6c6c3fa166975e5aebbe444605d736909e9eb75b'
         ['Yasuo Honda']
+      when '83c6ba18899a9f797d79726ca0078bdf618ec3d4'
+        ['S. Brent Faulkner']
       else
         nil
       end

--- a/test/credits/hard_coded_authors_test.rb
+++ b/test/credits/hard_coded_authors_test.rb
@@ -34,6 +34,7 @@ module Credits
       assert_contributor_names '4f1472d', 'John Bampton'
       assert_contributor_names 'fdbc55b', 'Yasuo Honda'
       assert_contributor_names '6c6c3fa', 'Yasuo Honda'
+      assert_contributor_names '83c6ba1', 'S. Brent Faulkner'
     end
   end
 end


### PR DESCRIPTION
Seems like this comit is not linked to me (S. Brent Faulkner)

See: [CHANGELOG in commit](https://github.com/rails/rails/commit/83c6ba18899a9f797d79726ca0078bdf618ec3d4#diff-71625f744d6dd8a0ae8521ae8ab815d99c6472768cedff74344cc5b244f2897c)

See also: [original lighthouse record](https://rails.lighthouseapp.com/projects/8994/tickets/838-add-support-for-selective-resource-routes-2) 
