### PR TITLE
Add Takuma Yoshida mapping

### DIFF
--- a/app/models/names_manager/canonical_names.rb
+++ b/app/models/names_manager/canonical_names.rb
@@ -1086,6 +1086,7 @@ module NamesManager
     map 'Tadas Tamošauskas',          'Tadas Tamosauskas'
     map 'Takayuki Matsubara',         'ma2gedev'
     map 'Takoyaki Kamen',             'タコ焼き仮面'
+    map 'Takuma Yoshida',             'takmar', 'Takuma'
     map 'Tal Rotbart',                'redbeard'
     map 'Tanmay Sinha',               'tanmay3011'
     map 'Tarmo Tänav',                'tarmo', 'tarmo_t', 'Tarmo Täna'

--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -4563,6 +4563,14 @@ module Credits
       assert_contributor_names 'fa1ea34' ,'Mitsutaka Mimura'
     end
 
+    test 'takmar' do
+      assert_contributor_names 'ea49d27' ,'Takuma Yoshida'
+    end
+
+    test 'Takuma' do
+      assert_contributor_names 'de39164' ,'Takuma Yoshida'
+    end
+
     test 'tank-bohr' do
       assert_contributor_names 'f3101fd', 'Alexey Nikitin'
     end


### PR DESCRIPTION
<img width="599" alt="Screenshot 2024-02-10 at 15 04 42" src="https://github.com/rails/rails-contributors/assets/26132902/63e7ce68-95f7-4d3f-a663-62dd4ecfcc7b">

I created this PR because both commits originated from the same GitHub account.