### PR TITLE
Only toggle sidebar if it is closed

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,6 @@
 
 window.addEventListener("turbolinks:load", () => {
   if (window.matchMedia("(min-width: 768px)").matches) {
-    document.querySelector("#sidebar summary").click();
+    document.querySelector("#sidebar details:not(open) summary")?.click();
   }
 });


### PR DESCRIPTION
We were toggling the sidebar regardless of whether it was open or closed. This caused the back button to close the sidebar on the desktop instead of opening it (because it was already open).