### PR TITLE
test: fix ambiguous OID prefix canonical name test cases

### DIFF
--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -2064,7 +2064,7 @@ module Credits
     end
 
     test "jeff\100ministrycentered.com" do
-      assert_contributor_names 'a5991d8', 'Jeff Berg'
+      assert_contributor_names 'a5991d849175c2ae9b803486f61b610fad9fd87e', 'Jeff Berg'
     end
 
     test "jeff\100opendbms.com" do

--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -1460,7 +1460,7 @@ module Credits
     end
 
     test "evgeny.zislis\100gmail.com" do
-      assert_contributor_names '842ce34', 'Evgeny Zislis'
+      assert_contributor_names '842ce34bbcfb2d65b04a6e80bf8c168d7c17277d', 'Evgeny Zislis'
     end
 
     test 'f.svehla' do

--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -1460,7 +1460,7 @@ module Credits
     end
 
     test "evgeny.zislis\100gmail.com" do
-      assert_contributor_names '842ce34bbcfb2d65b04a6e80bf8c168d7c17277d', 'Evgeny Zislis'
+      assert_contributor_names '842ce34b', 'Evgeny Zislis'
     end
 
     test 'f.svehla' do
@@ -2064,7 +2064,7 @@ module Credits
     end
 
     test "jeff\100ministrycentered.com" do
-      assert_contributor_names 'a5991d849175c2ae9b803486f61b610fad9fd87e', 'Jeff Berg'
+      assert_contributor_names 'a5991d84', 'Jeff Berg'
     end
 
     test "jeff\100opendbms.com" do

--- a/test/support/assert_contributor_names.rb
+++ b/test/support/assert_contributor_names.rb
@@ -6,7 +6,11 @@ module AssertContributorNames
   def assert_contributor_names(sha1, *contributor_names, **options)
     begin
       commit = Commit.new_from_rugged_commit(REPO.repo.lookup(sha1))
-    rescue Rugged::OdbError
+    rescue Rugged::OdbError => e
+      if e.message == "ambiguous OID prefix - found multiple pack entries"
+        raise "#{sha1} is ambiguous, please use the full commit SHA"
+      end
+
       raise "#{sha1} was not found, please make sure the local Rails checkout is up to date"
     end
 


### PR DESCRIPTION
When submitting this PR:
- https://github.com/rails/rails-contributors/pull/310

I found that there were 2 tests failing in `main`.

I observed that other simple mapping PRs had unrelated failures:
- https://github.com/rails/rails-contributors/pull/286
- https://github.com/rails/rails-contributors/pull/288

I'm proposing:
1. Clarifying the ambiguous OID case from the Rails checkout is stale failure case
2. Disambiguate two `assert_contributor_names` cases by using the full SHA 