### PR TITLE
Update robots.txt to improve crawler access

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,14 +1,18 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 
-User-Agent: Google
+# Disallow everything by default
+User-Agent: *
+Disallow: /
+
+# Allow Google crawler
+User-Agent: Googlebot
 Allow: /
 
+# Allow DuckDuck crawler
 User-Agent: DuckDuckBot
 Allow: /
 
-User-Agent: bingbot
-Crawl-delay: 5
+# Allow Bing crawler
+User-Agent: Bingbot
 Allow: /
-
-User-Agent: *
-Disallow: /
+Crawl-delay: 5


### PR DESCRIPTION
Allow search engine visibility and ensures proper crawling behavior for Google.

Revise the robots.txt file to disallow all crawlers by default while allowing specific access for Googlebot, DuckDuckBot, and Bingbot. 

Currently, searching for "Rails contributors" on Google results in:

> No information is available for this page.


<img width="783" alt="image" src="https://github.com/user-attachments/assets/c87826c3-ab77-4775-b923-ed9232e04301" />

The reason is the page is blocked by Robots.txt
<img width="789" alt="image" src="https://github.com/user-attachments/assets/002c4f0e-30dd-4399-a259-9e09b80e206d" />

[Robots.txt validator](https://technicalseo.com/tools/robots-txt/) shows the site is disallowed if the User Agent is Googlebot.
<img width="884" alt="image" src="https://github.com/user-attachments/assets/abc276a2-784e-4281-a100-eca97c837609" />

Changing the User-Agent order allows Google to crawl the site.

<img width="886" alt="image" src="https://github.com/user-attachments/assets/f2d223f2-4088-4a96-bc4b-26aa97fa06eb" />
