### PR TITLE
Bump puma and related dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'sprockets-rails'
 
 gem 'rack', '< 3.0'
 gem 'pg'
-gem 'puma', '~> 5.6'
+gem 'puma', '~> 6.0'
 gem 'rugged', '1.7.2'
 gem 'unf'
 gem 'turbolinks', '~> 5'
@@ -28,10 +28,10 @@ group :test do
 end
 
 group :deployment do
-  gem 'capistrano', '~> 3.19',      require: false
-  gem 'capistrano-rails', '~> 1.6', require: false
-  gem 'capistrano-rvm', '0.1.2',    require: false
-  gem 'capistrano3-puma', '~> 5.2', require: false
+  gem 'capistrano', '~> 3.19',        require: false
+  gem 'capistrano-rails', '~> 1.6',   require: false
+  gem 'capistrano-rvm', '0.1.2',      require: false
+  gem 'capistrano3-puma', '~> 6.2.0', require: false
   gem 'rbnacl', '>= 3.2', '< 8.0'
   gem 'rbnacl-libsodium'
   gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,10 +93,10 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
-    capistrano3-puma (5.2.0)
+    capistrano3-puma (6.2.0)
       capistrano (~> 3.7)
       capistrano-bundler
-      puma (>= 4.0, < 6.0)
+      puma (>= 5.1, < 7.0)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -155,7 +155,7 @@ GEM
     pg (1.5.7)
     psych (5.1.2)
       stringio
-    puma (5.6.9)
+    puma (6.6.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.17)
@@ -265,11 +265,11 @@ DEPENDENCIES
   capistrano (~> 3.19)
   capistrano-rails (~> 1.6)
   capistrano-rvm (= 0.1.2)
-  capistrano3-puma (~> 5.2)
+  capistrano3-puma (~> 6.2.0)
   coffee-rails (~> 5.0.0)
   ed25519
   pg
-  puma (~> 5.6)
+  puma (~> 6.0)
   rack (< 3.0)
   rails (~> 7.2.1)
   rails-controller-testing

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,10 +8,13 @@ set :deploy_to, '/home/rails/rails-contributors'
 
 set :log_level, :info
 
-set :linked_files, %w{config/database.yml config/master.key}
+set :linked_files, %w{config/database.yml config/master.key config/puma/production.rb}
 set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets public/system public/assets rails.git}
 
 set :keep_releases, 5
 
 set :bundle_without, %w{development test deployment}.join(' ')
 set :bundle_gemfile, -> { release_path.join('Gemfile') }
+
+set :puma_bind, "unix:/tmp/rails-contributors.sock"
+set :puma_systemctl_user, :system

--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env puma
+
+directory '/home/rails/rails-contributors/current'
+rackup "/home/rails/rails-contributors/current/config.ru"
+environment 'production'
+
+pidfile "/home/rails/rails-contributors/shared/tmp/pids/puma.pid"
+state_path "/home/rails/rails-contributors/shared/tmp/pids/puma.state"
+stdout_redirect '/home/rails/rails-contributors/shared/log/puma_access.log', '/home/rails/rails-contributors/shared/log/puma_error.log', true
+
+threads 0,16
+
+bind 'unix:/tmp/rails-contributors.sock'
+
+workers 1
+
+restart_command 'bundle exec puma'
+
+prune_bundler
+
+on_restart do
+  puts 'Refreshing Gemfile'
+  ENV["BUNDLE_GEMFILE"] = "/home/rails/rails-contributors/current/Gemfile"
+end


### PR DESCRIPTION
This error was found in the logs:

```
$ tail -50 current/log/puma_error.log
...
puma-5.6.8/lib/rack/version_restriction.rb:12:in `<top (required)>':
Puma 5 is not compatible with Rack 3, please upgrade to Puma 6 or higher. (StandardError)
```

We probably also need to deal with updating capistrano-puma:
https://github.com/seuros/capistrano-puma?tab=readme-ov-file#upgrading-from-version-5x-to-6x

/cc @fxn I haven't dug that far in yet, just wanted to post this in case people are wondering what happened. I'm not familiar with how this gets deploys, so pointers welcome :bow: